### PR TITLE
feat: add Windows build helper

### DIFF
--- a/build-win.bat
+++ b/build-win.bat
@@ -1,0 +1,4 @@
+@echo off
+npm install
+npm run build:win
+pause

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Tu Nombre <tu@correo.com>",
   "scripts": {
     "start": "electron .",
-    "build": "electron-builder"
+    "build": "electron-builder",
+    "build:win": "electron-builder --win"
   },
   "build": {
     "appId": "com.5470.wallet",


### PR DESCRIPTION
## Summary
- add `build:win` script for electron-builder packaging on Windows
- provide `build-win.bat` for one-click install and build

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build -- --win` *(fails: Get "https://github.com/electron/electron/releases/download/v37.2.6/electron-v37.2.6-win32-x64.zip": Forbidden)*
- `npm install` *(fails: ssh: connect to host github.com port 22: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6893122ce4b0833381d566aeee3eefcc